### PR TITLE
[CENG-5726] ignore rbenv

### DIFF
--- a/pantastic/pantastic.py
+++ b/pantastic/pantastic.py
@@ -50,21 +50,21 @@ class Pantastic:
             for user in os.listdir(home_dir):
                 user_path = os.path.join(home_dir, user)
                 
-                # Check for .rbenv directory
+                # Check for .rbenv directory, and ignores it if present
                 rbenv_path = os.path.join(user_path, '.rbenv')
                 if os.path.isdir(rbenv_path):
                     self.ignore_paths.append(rbenv_path)
                     if self.verbose:
                         click.echo(f"Added to ignore paths: {rbenv_path}")
                 
-                # Check for .bundle directory
+                # Check for .bundle directory, and ignores it if present
                 bundle_path = os.path.join(user_path, '.bundle')
                 if os.path.isdir(bundle_path):
                     self.ignore_paths.append(bundle_path)
                     if self.verbose:
                         click.echo(f"Added to ignore paths: {bundle_path}")
 
-                # Check for .vscode-server directory
+                # Check for .vscode-server directory, and ignores it if present
                 vscode_path = os.path.join(user_path, '.vscode-server')
                 if os.path.isdir(vscode_path):
                     self.ignore_paths.append(vscode_path)

--- a/pantastic/pantastic.py
+++ b/pantastic/pantastic.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import click
 import mmap
@@ -41,20 +40,40 @@ class Pantastic:
         self.ignore_paths = ignore_paths
         self.verbose = verbose
 
+        # Defines paths that should be ignored
+        self.add_dynamic_ignore_paths()
+
+    def add_dynamic_ignore_paths(self):
+        home_dir = '/home'
+        if os.path.isdir(home_dir):
+            for user in os.listdir(home_dir):
+                user_path = os.path.join(home_dir, user)
+                
+                # Check for .rbenv directory
+                rbenv_path = os.path.join(user_path, '.rbenv')
+                if os.path.isdir(rbenv_path):
+                    self.ignore_paths.append(rbenv_path)
+                    if self.verbose:
+                        click.echo(f"Added to ignore paths: {rbenv_path}")
+                
+                # Check for .bundle directory
+                bundle_path = os.path.join(user_path, '.bundle')
+                if os.path.isdir(bundle_path):
+                    self.ignore_paths.append(bundle_path)
+                    if self.verbose:
+                        click.echo(f"Added to ignore paths: {bundle_path}")
+
+                # Check for .vscode-server directory
+                vscode_path = os.path.join(user_path, '.vscode-server')
+                if os.path.isdir(vscode_path):
+                    self.ignore_paths.append(vscode_path)
+                    if self.verbose:
+                        click.echo(f"Added to ignore paths: {vscode_path}")
+
     def scan_location(self, location):
         """
         Walk a directory path recursively
         """
-        # ignore .rbenv in home dirs
-        home_dir = '/home'
-        if os.path.exists(home_dir) and os.path.isdir(home_dir):
-            for user_dir in os.listdir(home_dir):
-                user_path = os.path.join(home_dir, user_dir, '.rbenv')
-                if os.path.isdir(user_path):
-                    self.ignore_paths.append(user_path)
-                    if self.verbose:
-                        click.echo(f"Added to ignore paths: {user_path}")
-
         if self.output:
             self.output_handle = open(self.output, 'w')
             self.output_handle.write("filename,issuer,number\n")

--- a/pantastic/pantastic.py
+++ b/pantastic/pantastic.py
@@ -45,6 +45,16 @@ class Pantastic:
         """
         Walk a directory path recursively
         """
+        # ignore .rbenv in home dirs
+        home_dir = '/home'
+        if os.path.exists(home_dir) and os.path.isdir(home_dir):
+            for user_dir in os.listdir(home_dir):
+                user_path = os.path.join(home_dir, user_dir, '.rbenv')
+                if os.path.isdir(user_path):
+                    self.ignore_paths.append(user_path)
+                    if self.verbose:
+                        click.echo(f"Added to ignore paths: {user_path}")
+
         if self.output:
             self.output_handle = open(self.output, 'w')
             self.output_handle.write("filename,issuer,number\n")

--- a/pantastic/pantastic.py
+++ b/pantastic/pantastic.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import click
 import mmap


### PR DESCRIPTION
Updated the Pantastic code to ignore `.rbenv`, `.bundle`, and `.vscode-server` directories within `/home/$User` directories. Tested on import-export hosts, and verified that its working.